### PR TITLE
Fix mips64-binutils for Fedora 31 and similar Linux distros

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,6 +205,8 @@ IRIX_ROOT := tools/ido5.3_compiler
 
 ifeq ($(shell type mips-linux-gnu-ld >/dev/null 2>/dev/null; echo $$?), 0)
   CROSS := mips-linux-gnu-
+else ifeq ($(shell type mips64-linux-gnu-ld >/dev/null 2>/dev/null; echo $$?), 0)
+  CROSS := mips64-linux-gnu-
 else
   CROSS := mips64-elf-
 endif


### PR DESCRIPTION
On Fedora the mips64 binutils package has a different naming scheme compared to other Linux distros.
The package is called `binutils-mips64-linux-gnu.x86_64`.
My check sees if Fedora's naming scheme is used.