### PR TITLE
Clarify comment about KtQ speed

### DIFF
--- a/src/game/behaviors/koopa.inc.c
+++ b/src/game/behaviors/koopa.inc.c
@@ -616,8 +616,8 @@ static void koopa_the_quick_act_race(void) {
 
                     if (o->parentObj->oKoopaRaceEndpointRaceStatus != 0 && o->oDistanceToMario > 1500.0f
                         && (o->oPathedPrevWaypointFlags & WAYPOINT_MASK_00FF) < 28) {
-                        // Move faster if mario has already finished the race or
-                        // cheated by shooting from cannon
+                        // Move faster if mario has already finished the race
+                        // but only if KtQ is far from mario and the finish line
                         o->oKoopaAgility = 8.0f;
                     } else if (o->oKoopaTheQuickRaceIndex != KOOPA_THE_QUICK_BOB_INDEX) {
                         o->oKoopaAgility = 6.0f;


### PR DESCRIPTION
(Chatted about this in #help in the discord about a week ago)

The original comment confused me when I was examining KtQ code, because it doesn't matter if Mario finishes the race fairly or finishes the race by cheating, only that he has finishes the race. This is what the code is checking for (oKoopaRaceEndpointRaceStatus!=0 matches both "Mario cheated" and "Mario didn't cheat").

I removed the part about the cannon, since it's implied by finishing the race, and added a line of English to help explain the rest of the conditional