### PR TITLE
Added ALIGN8 to 'main noload' segment

### DIFF
--- a/sm64.ld
+++ b/sm64.ld
@@ -654,6 +654,8 @@ SECTIONS
       BUILD_DIR/libultra.a:kdebugserver.o(.bss*);
       BUILD_DIR/libultra.a:*.o(.bss*);
 #endif
+
+      . = ALIGN(0x8);
    }
    END_NOLOAD(main)
    _mainSegmentNoloadSizeLo = SIZEOF (.main.noload) & 0xffff;


### PR DESCRIPTION
If main noload segment is not aligned by 8, entry.s function will
loop infinitely as it is expecting size being divisble by 8.
This commit fixes potential deadlock for romhacks.