### PR TITLE
Add Docker Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:latest
+
+RUN apt update
+RUN apt install -y wget build-essential pkg-config git binutils-mips-linux-gnu python3 zlib1g-dev libaudiofile-dev bsdmainutils
+
+RUN wget https://github.com/n64decomp/qemu-irix/releases/download/v2.11-deb/qemu-irix-2.11.0-2169-g32ab296eef_amd64.deb
+RUN dpkg -i qemu-irix-2.11.0-2169-g32ab296eef_amd64.deb
+
+RUN mkdir /sm64
+WORKDIR /sm64
+ENV PATH="/sm64/tools:${PATH}"
+
+CMD echo 'usage: docker run --rm --mount type=bind,source="$(pwd)",destination=/sm64 sm64 make VERSION=<version> -j4'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,26 @@
-FROM ubuntu:latest
+FROM ubuntu:18.04 as build
 
-RUN apt update
-RUN apt install -y wget build-essential pkg-config git binutils-mips-linux-gnu python3 zlib1g-dev libaudiofile-dev bsdmainutils
+RUN apt-get update && \
+    apt-get install -y \
+        binutils-mips-linux-gnu \
+        bsdmainutils \
+        build-essential \
+        libaudiofile-dev \
+        pkg-config \
+        python3 \
+        wget \
+        zlib1g-dev
 
-RUN wget https://github.com/n64decomp/qemu-irix/releases/download/v2.11-deb/qemu-irix-2.11.0-2169-g32ab296eef_amd64.deb
-RUN dpkg -i qemu-irix-2.11.0-2169-g32ab296eef_amd64.deb
+RUN wget \
+        https://github.com/n64decomp/qemu-irix/releases/download/v2.11-deb/qemu-irix-2.11.0-2169-g32ab296eef_amd64.deb \
+        -O qemu.deb && \
+    echo 8170f37cf03a08cc2d7c1c58f10d650ea0d158f711f6916da9364f6d8c85f741 qemu.deb | sha256sum --check && \
+    dpkg -i qemu.deb && \
+    rm qemu.deb
 
 RUN mkdir /sm64
 WORKDIR /sm64
 ENV PATH="/sm64/tools:${PATH}"
 
-CMD echo 'usage: docker run --rm --mount type=bind,source="$(pwd)",destination=/sm64 sm64 make VERSION=<version> -j4'
+CMD echo 'usage: docker run --rm --mount type=bind,source="$(pwd)",destination=/sm64 sm64 make VERSION=${VERSION:-us} -j4\n' \
+         'see https://github.com/n64decomp/sm64/blob/master/README.md for advanced usage'

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To build we simply have to mount our local filesystem into the docker container 
 docker run --rm --mount type=bind,source="$(pwd)",destination=/sm64 sm64 make VERSION=us -j4
 
 # if your host system is linux you need to tell docker what user should own the output files
-docker run --rm --mount type=bind,source="$(pwd)",destination=/sm64 --user "$(id -u):$(id -g)" sm64 make VERSION=us -j4
+docker run --rm --mount type=bind,source="$(pwd)",destination=/sm64 --user $UID:$UID sm64 make VERSION=us -j4
 ```
 
 Resulting artifacts can be found in the `build` directory.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,33 @@ A prior copy of the game is required to extract the required assets.
 
 ## Installation
 
+### Docker
+
+#### 1. Copy baserom(s) for asset extraction
+
+For each version (jp/us/eu) that you want to build a ROM for, put an existing ROM at
+`./baserom.<version>.z64` for asset extraction.
+
+#### 2. Create docker image
+
+```bash
+docker build -t sm64 .
+```
+
+#### 3. Build
+
+To build we simply have to mount our local filesystem into the docker container and build.
+
+```bash
+# for example if you have baserom.us.z64 in the project root
+docker run --rm --mount type=bind,source="$(pwd)",destination=/sm64 sm64 make VERSION=us -j4
+
+# if your host system is linux you need to tell docker what user should own the output files
+docker run --rm --mount type=bind,source="$(pwd)",destination=/sm64 --user "$(id -u):$(id -g)" sm64 make VERSION=us -j4
+```
+
+Resulting artifacts can be found in the `build` directory.
+
 ### Linux
 
 #### 1. Copy baserom(s) for asset extraction


### PR DESCRIPTION
This PR ~~blatantly rips off~~ builds upon the groundwork of https://github.com/n64decomp/sm64/pull/24 with the added benefit of having close to normal build times!

Clean build
```fish
❯ time docker run --rm --mount type=bind,source=(pwd),destination=/sm64 --user (id -u):(id -g) sm64 make VERSION=us -j12
...
________________________________________________________
Executed in   21.93 secs   fish           external
   usr time   93.08 millis  878.00 micros   92.20 millis
   sys time  188.38 millis    0.00 micros  188.38 millis

❯ sha1sum build/us/sm64.us.z64                                                                                  20:42:13
9bef1128717f958171a4afac3ed78ee2bb4e86ce  build/us/sm64.us.z64
```

Cached build
```fish
❯ time docker run --rm --mount type=bind,source=(pwd),destination=/sm64 --user (id -u):(id -g) sm64 make VERSION=us -j4
build/us/sm64.us.z64: OK
________________________________________________________
Executed in    3.11 secs   fish           external
   usr time   33.35 millis  1293.00 micros   32.05 millis
   sys time   28.02 millis    0.00 micros   28.02 millis
```

This is accomplished by setting up the environment in the docker build, but only compiling during a run. As a result it only takes about a second to set up the environment and start compiling, meaning this could be used for development if one really wanted to.

Also the compiled files/rom are already in the host file system, no need to pull them out of the container.