### PR TITLE
Set the program name in skyconv

### DIFF
--- a/tools/skyconv.c
+++ b/tools/skyconv.c
@@ -69,7 +69,7 @@ static const TableDimension TABLE_DIMENSIONS[ImageType_MAX] = {
 TextureTile *tiles;
 ImageType type = InvalidType;
 OperationMode mode = InvalidMode;
-char *programName;
+const char programName[] = "skyconv";
 char *input, *output;
 char *writeDir;
 char skyboxName[256];


### PR DESCRIPTION
Without setting the name, the tool crashes when you run it with no arguments.