### PR TITLE
Replace fixed dialogID in play_dialog_sound to DIALOG_COUNT

### DIFF
--- a/src/audio/external.c
+++ b/src/audio/external.c
@@ -2123,7 +2123,7 @@ void func_80320A4C(u8 bankIndex, u8 arg1) {
 void play_dialog_sound(u8 dialogID) {
     u8 speaker;
 
-    if (dialogID >= 170) {
+    if (dialogID >= DIALOG_COUNT) {
         dialogID = 0;
     }
 


### PR DESCRIPTION
This PR replaces the fixed `170` ID inside an if statement in the `play_dialog_sound` function to the dynamic `DIALOG_COUNT` definition (from `include/dialog_ids.h`).  This should makes it slightly more easier to add additional dialogs when creating hacks.

Compare checks are OK'd.