### PR TITLE
Remove erroneous long double casts from audiofile.cpp

### DIFF
--- a/tools/audiofile/audiofile.cpp
+++ b/tools/audiofile/audiofile.cpp
@@ -5075,7 +5075,7 @@ bool ModuleState::fileModuleHandlesSeeking() const
 
 status ModuleState::setup(AFfilehandle file, Track *track)
 {
-	AFframecount fframepos = std::llrint((long double)track->nextvframe * track->f.sampleRate / track->v.sampleRate);
+	AFframecount fframepos = std::llrint(track->nextvframe * track->f.sampleRate / track->v.sampleRate);
 	bool isReading = file->m_access == _AF_READ_ACCESS;
 
 	if (!track->v.isUncompressed())
@@ -5146,11 +5146,11 @@ status ModuleState::setup(AFfilehandle file, Track *track)
 		if (track->totalfframes == -1)
 			track->totalvframes = -1;
 		else
-			track->totalvframes = std::llrint((long double)track->totalfframes *
+			track->totalvframes = std::llrint(track->totalfframes *
 				(track->v.sampleRate / track->f.sampleRate));
 
 		track->nextfframe = fframepos;
-		track->nextvframe = std::llrint((long double)fframepos * track->v.sampleRate / track->f.sampleRate);
+		track->nextvframe = std::llrint(fframepos * track->v.sampleRate / track->f.sampleRate);
 
 		m_isDirty = false;
 


### PR DESCRIPTION
Those were added in the process of trying to get the PC port fork to compile on someone's PowerPC machine and are not present in the original [libaudiofile](https://github.com/mpruett/audiofile/blob/master/libaudiofile/modules/ModuleState.cpp#L111) [source](https://github.com/mpruett/audiofile/blob/master/libaudiofile/modules/ModuleState.cpp#L182) [code](https://github.com/mpruett/audiofile/blob/master/libaudiofile/modules/ModuleState.cpp#L186) nor in the audiofile [patch](https://github.com/n64decomp/sm64/blob/master/tools/util/audiofile_strip.patch) in `util`.
As it turned out later, that causes libaudiofile to fail while reading samples from some AIFF files (generally ones that had an `INST` chunk added to them for looping), in turn causing tabledesign to fail on said files as well.
This issue also affects sm64-port, since that uses the same `audiofile.cpp`.