### PR TITLE
Position coin counter from right edge of screen

### DIFF
--- a/src/game/hud.c
+++ b/src/game/hud.c
@@ -275,9 +275,9 @@ void render_hud_mario_lives(void) {
  * Renders the amount of coins collected.
  */
 void render_hud_coins(void) {
-    print_text(168, HUD_TOP_Y, "+"); // 'Coin' glyph
-    print_text(184, HUD_TOP_Y, "*"); // 'X' glyph
-    print_text_fmt_int(198, HUD_TOP_Y, "%d", gHudDisplay.coins);
+    print_text(GFX_DIMENSIONS_RECT_FROM_RIGHT_EDGE(152), HUD_TOP_Y, "+"); // 'Coin' glyph
+    print_text(GFX_DIMENSIONS_RECT_FROM_RIGHT_EDGE(136), HUD_TOP_Y, "*"); // 'X' glyph
+    print_text_fmt_int(GFX_DIMENSIONS_RECT_FROM_RIGHT_EDGE(122), HUD_TOP_Y, "%d", gHudDisplay.coins);
 }
 
 #ifdef VERSION_JP


### PR DESCRIPTION
Changes the currently fixed X coordinates of the coin counter HUD to use `GFX_DIMENSIONS_RECT_FROM_RIGHT_EDGE` so the counter will be properly right-aligned in widescreen like it is when playing in 4:3.

(Edit: this change was made before the relicensing - it's of course still fine to merge with the new license)