### PR TITLE
Make build output cleaner

### DIFF
--- a/Makefile.split
+++ b/Makefile.split
@@ -148,7 +148,8 @@ endef
 ifneq ($(MAKECMDGOALS),clean)
 ifneq ($(MAKECMDGOALS),distclean)
 $(BUILD_DIR)/level_rules.mk: levels/level_rules.mk levels/level_defines.h
-	$(CPP) $(VERSION_CFLAGS) -I . -o $@ $<
+	@$(PRINT) "$(GREEN)Preprocessing level make rules $(NO_COL)\n"
+	@$(CPP) $(VERSION_CFLAGS) -I . -o $@ $<
 include $(BUILD_DIR)/level_rules.mk
 endif
 endif
@@ -165,9 +166,11 @@ $(eval $(call level_rules,menu,generic)) # Menu (File Select)
 
 # Ending cake textures are generated in a special way
 $(BUILD_DIR)/levels/ending/cake_eu.inc.c: levels/ending/cake_eu.png
-	$(SKYCONV) --type cake-eu --split $^ $(BUILD_DIR)/levels/ending
+	@$(PRINT) "$(GREEN)SkyConverting $(YELLOW)$< $(GREEN)to:  $(BLUE)$@ $(NO_COL)\n"
+	@$(SKYCONV) --type cake-eu --split $^ $(BUILD_DIR)/levels/ending
 $(BUILD_DIR)/levels/ending/cake.inc.c: levels/ending/cake.png
-	$(SKYCONV) --type cake --split $^ $(BUILD_DIR)/levels/ending
+	@$(PRINT) "$(GREEN)SkyConverting $(YELLOW)$< $(GREEN)to:  $(BLUE)$@ $(NO_COL)\n"
+	@$(SKYCONV) --type cake --split $^ $(BUILD_DIR)/levels/ending
 
 # --------------------------------------
 # Texture Bin Rules
@@ -235,7 +238,8 @@ $(BUILD_DIR)/bin/eu/translation_fr.elf: SEGMENT_ADDRESS := 0x19000000
 # --------------------------------------
 
 $(BUILD_DIR)/bin/%_skybox.c: textures/skyboxes/%.png
-	$(SKYCONV) --type sky --split $^ $(BUILD_DIR)/bin
+	@$(PRINT) "$(GREEN)SkyConverting $(YELLOW)$< $(GREEN)to:  $(BLUE)$@ $(NO_COL)\n"
+	@$(SKYCONV) --type sky --split $^ $(BUILD_DIR)/bin
 
 $(BUILD_DIR)/bin/%_skybox.elf: SEGMENT_ADDRESS := 0x0A000000
 


### PR DESCRIPTION
This PR mutes the display of commands that are ran on build, and replaces that output with cleanly colored text explaining what is being done. 

This makes it a lot easier to find the source of warnings or errors; instead of fishing through [a mess of ``qemu-irix`` calls](https://asciinema.org/a/nDfW3gnRMakLPSJrCcgeYYBEy), you are instead presented with [an easier to read list](https://asciinema.org/a/GSHu5q5RvqiAkvNPKzBGaHVXO).

This does not affect code at all, and all 3 regions (Shindou untested due to it's experimental state) are ``OK``. I will gladly take suggestions on wording of messages, or if there is room for improvement in it's implementation.