### PR TITLE
Use the correct field name for bhvMrIBlueCoin

### DIFF
--- a/data/behavior_data.c
+++ b/data/behavior_data.c
@@ -874,7 +874,7 @@ const BehaviorScript bhvMrIBlueCoin[] = {
     OR_INT(oFlags, OBJ_FLAG_UPDATE_GFX_POS_AND_ANGLE),
     BILLBOARD(),
     SET_INT(oIntangibleTimer, 0),
-    SET_FLOAT(oMrIUnk110, 20),
+    SET_FLOAT(oCoinUnk110, 20),
     SET_INT(oAnimState, -1),
     SET_OBJ_PHYSICS(/*Wall hitbox radius*/ 30, /*Gravity*/ -400, /*Bounciness*/ -70, /*Drag strength*/ 1000, /*Friction*/ 1000, /*Buoyancy*/ 200, /*Unused*/ 0, 0),
     CALL_NATIVE(bhv_coin_init),


### PR DESCRIPTION
bhvMrIBlueCoin is a coin object, so it should use oCoinUnk110 instead of oMrIUnk110 in its script in behavior_data.c