### PR TITLE
use r+b mode for libultra.a patch tool

### DIFF
--- a/tools/patch_libultra_math.c
+++ b/tools/patch_libultra_math.c
@@ -79,7 +79,7 @@ struct ar_header {
 #define FLAGS_MIPS3 0x20
 #define FLAGS_O32ABI 0x100000 
 int main(int argc, char **argv) {
-    FILE *f = fopen(argv[1], "r+");
+    FILE *f = fopen(argv[1], "r+b");
 
     if (f == NULL) {
         printf("Failed to open file! %s\n", argv[1]);


### PR DESCRIPTION
no one noticed this one so i will edit the description:

affects on windows systems but not on unix (linux)
since the file is binary, it should use the binary mode too.