### PR TITLE
Changed apply_patch to use the --merge flag

### DIFF
--- a/tools/apply_patch.sh
+++ b/tools/apply_patch.sh
@@ -13,7 +13,7 @@ fi
 read -p "Do you wish to apply the patch '$1'? [Y/N] " response
 case "$response" in
     Y|y)
-	patch -p1 < "$1"
+	patch -p1 --merge < "$1"
 	;;
     N|n)
 	echo 'Quit'


### PR DESCRIPTION
This allows users to resolve merge conflicts with patches in code as opposed to generating .rej files. This is probably a preferred behavior as it makes it very clear when patches fail to apply and prevents compilation until merging is resolved, as opposed to the current method which allows compilation even when patches have been partially applied.

This does not affect the contents of the rom built from this repo.