### PR TITLE
Fix build with make-4.4.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -514,9 +514,11 @@ $(BUILD_DIR)/%.ci4: %.ci4.png
 $(BUILD_DIR)/%.elf: $(BUILD_DIR)/%.o
 	$(call print,Linking ELF file:,$<,$@)
 	$(V)$(LD) -e 0 -Ttext=$(SEGMENT_ADDRESS) -Map $@.map -o $@ $<
-# Override for leveldata.elf, which otherwise matches the above pattern
+# Override for leveldata.elf, which otherwise matches the above pattern.
+# Has to be a static pattern rule for make-4.4 and above to trigger the second
+# expansion.
 .SECONDEXPANSION:
-$(BUILD_DIR)/levels/%/leveldata.elf: $(BUILD_DIR)/levels/%/leveldata.o $(BUILD_DIR)/bin/$$(TEXTURE_BIN).elf
+$(LEVEL_ELF_FILES): $(BUILD_DIR)/levels/%/leveldata.elf: $(BUILD_DIR)/levels/%/leveldata.o $(BUILD_DIR)/bin/$$(TEXTURE_BIN).elf
 	$(call print,Linking ELF file:,$<,$@)
 	$(V)$(LD) -e 0 -Ttext=$(SEGMENT_ADDRESS) -Map $@.map --just-symbols=$(BUILD_DIR)/bin/$(TEXTURE_BIN).elf -o $@ $<
 

--- a/Makefile.split
+++ b/Makefile.split
@@ -39,6 +39,8 @@ ACTOR_GROUPS := \
 
 LEVEL_FILES := $(addsuffix leveldata,$(LEVEL_DIRS))
 
+LEVEL_ELF_FILES := $(foreach level_dir,$(LEVEL_DIRS),$(BUILD_DIR)/levels/$(level_dir)leveldata.elf)
+
 SEG_FILES := \
     $(SEGMENTS:%=$(BUILD_DIR)/bin/%.elf) \
     $(ACTOR_GROUPS:%=$(BUILD_DIR)/actors/%.elf) \


### PR DESCRIPTION
make-4.4 changed the behaviour of .SECONDEXPANSION to only expand rules that were explicitly used by the currently built target. Because leveldata used .SECONDEXPANSION to override an implicit pattern rule with another implicit pattern rule, the override wasn't considered for expansion and never used. By replacing the implicit pattern override with a static pattern override, i.e. by explicitly listing the dependencies, the rule takes precedence over the implicit pattern rule ($(BUILD_DIR)/*.elf) and gets expanded.

This patch fixes the build for make-4.4, and was also tested with make-4.3.