### PR TITLE
add ido support for FreeBSD

### DIFF
--- a/tools/ido-static-recomp/Makefile
+++ b/tools/ido-static-recomp/Makefile
@@ -35,6 +35,8 @@ ifeq ($(OS),Windows_NT)
   DETECTED_OS := windows
 else ifeq ($(UNAME_S),Linux)
   DETECTED_OS := linux
+else ifeq ($(UNAME_S),FreeBSD)
+  DETECTED_OS := freebsd
 else ifeq ($(UNAME_S),Darwin)
   DETECTED_OS := macos
   MAKE := gmake
@@ -121,6 +123,10 @@ endif
 ifeq ($(DETECTED_OS),linux)
 # For traceback
 $(RECOMP_ELF): LDFLAGS   += -Wl,-export-dynamic
+endif
+ifeq ($(DETECTED_OS),freebsd)
+# For traceback
+$(RECOMP_ELF): LDFLAGS   += -Wl,-export-dynamic -lexecinfo
 endif
 
 # Too many warnings, disable everything for now...


### PR DESCRIPTION
add via ifdef __FreeBSD__ pre-processor directives in libc_impl.c 

This code may work in OpenBSD and NetBSD with suitable arch definition flags added to the pre-processor checks, but I have no such systems now to test with. I would imagine they have the same libc and procfs implementation, or similar enough.

Modifies:
find_bin_dir() by wrapping FreeBSD procfs syntax to current process using existing linux code as template

wrapper_tempnam dir seems to be coming in blank, this creates a temp file at root fs. not sure if this is truly coming in at root or if glibc checking on appropriates of tempfile is saving linux, while bsd libc does no checking for sanity. forced dir to "/tmp/" and resolved issue. not satisfying result, but working, and /tmp seems to be where these should go anyway.

wrapper___assert() changed redirection to __assert() using bsd call ordering and forcing unused extra parameter in bsd libc to "undefinedfunc". FreeBSD allows defining a function in the __assert() call

results:
$ gsha1sum build/us/sm64.us.z64 baserom.us.z64
9bef1128717f958171a4afac3ed78ee2bb4e86ce  build/us/sm64.us.z64
9bef1128717f958171a4afac3ed78ee2bb4e86ce  baserom.us.z64
Matching Rom OK reported from build as well

this requires a custom built binutils for mips64-elf, I can tweak the readme.md or whereever the guides are if my memory is off if you want. I am also working on a toolchain Makefile to do the work more easily, including making a gcc newlib mips64-elf compiler that also produces runnable roms, obviously just not matching. Let me know in a comment on this if you want me to go that route. For the guide I can explain the configure options to just make binutils, or ultimatley include my tool, or I can put my tools into my own repo and reference given the aim on this project is to only produce matching roms, which I can respect. binutils is trivial, to explain in a guide along with some creative path tweaks and some symlinks to address some quality of life things to avoid editing the project Makefile to build things in bsd. GCC is a beast to figure out on your own, but generally the arch linux build scripts were a great guide. Let me know, now time to make the hacks of my dreams...