### PR TITLE
Add bsdmainutils to the Docker packages required

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ RUN apt-get update && \
         build-essential \
         git \
         pkgconf \
-        python3
+        python3 \
+        bsdmainutils
 
 RUN mkdir /sm64
 WORKDIR /sm64


### PR DESCRIPTION
People building with Docker may experience an error in the compile process due to "hexdump" not being found. Adding bsdmainutils as a necessary package to the dockerfile resolves this.