### PR TITLE
Fix compilation for tools/armips.cpp by removing #undef __STRICT_ANSI__

### DIFF
--- a/tools/armips.cpp
+++ b/tools/armips.cpp
@@ -32,7 +32,6 @@ SOFTWARE.
 
 
 #define _CRT_SECURE_NO_WARNINGS
-#undef __STRICT_ANSI__
 
 #if defined(__clang__)
 #if __has_feature(cxx_exceptions)
@@ -15903,16 +15902,19 @@ int runFromCommandLine(const StringList& arguments, ArmipsArguments settings)
 #include <vector>
 #include <algorithm>
 
-#ifndef _WIN32
-#include <strings.h>
-#define _stricmp strcasecmp
-#endif
+#include <cctype>
 
 static bool stringEqualInsensitive(const std::string& a, const std::string& b)
 {
 	if (a.size() != b.size())
 		return false;
-	return _stricmp(a.c_str(),b.c_str()) == 0;
+
+	auto compare = [](char c1, char c2)
+ 	{
+ 		return std::tolower(c1) == std::tolower(c2);
+ 	};
+
+   return std::equal(a.begin(), a.end(), b.begin(), compare);
 }
 
 bool compareSection(ElfSection* a, ElfSection* b)


### PR DESCRIPTION
At the time the single file for armips was created, there was a reliance on non-standard function strcasecmp() in armips.  According to armips/79bf12b02ffe1feb39e4e529fb13ccedf3102339, this was required to fix the build with Cygwin at the time.  However, this breaks headers which are configured based on __STRICT_ANSI__.  For me, this resulted in compilation failing with GCC 14.2.1 on Arch Linux.

Commit armips/946338745955fef3a5528eefeb947751aae9363c replaces the one use of strcasecmp with its own implementation, and commit armips/2205628e245e9f4ca5fc90cb7c39fe8457729077 removes the #undef __STRICT_ANSI.

I simply applied the fix from armips/946338745955fef3a5528eefeb947751aae9363c and removed the #undef __STRICT_ANSI__, which fixes the build.