### PR TITLE
Security Fix: Add explicit bounds check for numCoefficients in AudioFile library

### DIFF
--- a/tools/audiofile/audiofile.cpp
+++ b/tools/audiofile/audiofile.cpp
@@ -11183,7 +11183,11 @@ status WAVEFile::parseFormat(const Tag &id, uint32_t size)
 
 			/* numCoefficients should be at least 7. */
 			assert(numCoefficients >= 7 && numCoefficients <= 255);
-
+			if (numCoefficients < 7 || numCoefficients > 255)
+			{
+				_af_error(AF_BAD_HEADER, "Bad number of coefficients");
+				return AF_FAIL;
+			}
 			m_msadpcmNumCoefficients = numCoefficients;
 
 			for (int i=0; i<m_msadpcmNumCoefficients; i++)


### PR DESCRIPTION
**Description**
This PR fixes a security vulnerability in the AudioFile library that was cloned from libaudiofile but did not receive the security patch applied in the original repository. The original issue was reported and fixed under antlarr/audiofile@c48e4c6. This PR applies the same patch as the one in the original repository to eliminate the vulnerability.
**References**
https://github.com/antlarr/audiofile/commit/c48e4c6503f7dabd41f11d4c9c7b7f8960e7f2c0
Similar to CVE-2018-13440