### PR TITLE
Removed bad make recipe dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -582,7 +582,7 @@ $(BUILD_DIR)/%.elf: $(BUILD_DIR)/%.o
 	$(V)$(LD) -e 0 -Ttext=$(SEGMENT_ADDRESS) -Map $@.map -o $@ $<
 # Override for leveldata.elf, which otherwise matches the above pattern
 .SECONDEXPANSION:
-$(BUILD_DIR)/levels/%/leveldata.elf: $(BUILD_DIR)/levels/%/leveldata.o $(BUILD_DIR)/bin/$$(TEXTURE_BIN).elf
+$(BUILD_DIR)/levels/%/leveldata.elf: $(BUILD_DIR)/levels/%/leveldata.o 
 	$(call print,Linking ELF file:,$<,$@)
 	$(V)$(LD) -e 0 -Ttext=$(SEGMENT_ADDRESS) -Map $@.map --just-symbols=$(BUILD_DIR)/bin/$(TEXTURE_BIN).elf -o $@ $<
 


### PR DESCRIPTION
I'm running OSX (15.5) and was getting this error during build:
Linking ELF file: build/us/levels/bbh/leveldata.o -> build/us/levels/bbh/leveldata.elf
mips64-elf-ld: build/us/levels/bbh/leveldata.o:(.data+0x6af4): undefined reference to `spooky_09008800'
mips64-elf-ld: build/us/levels/bbh/leveldata.o:(.data+0x6dfc): undefined reference to `spooky_09004800'
mips64-elf-ld: build/us/levels/bbh/leveldata.o:(.data+0x6e8c): undefined reference to `spooky_0900A000'
mips64-elf-ld: build/us/levels/bbh/leveldata.o:(.data+0x6ee4): undefined reference to `spooky_09003800'
...

I resolved the issue by removing a dependency in the relevant recipe. I think there is some issue with the resolution of TEXTURE_BIN when evaluating the recipe. 

I don't think that second dependency is ever actually needed in the recipe header (although it is used in the build command). Whenever we build a leveldata.elf file, we are just assuming that `$(TEXTURE_BIN).elf` exists. If `$(TEXTURE_BIN).elf` doesn't exist, you'll get an error regardless of whether it is included in the recipe header.

There might be a better solution here, but this is the best I could find