### PR TITLE
Fix armips build on GCC 15

### DIFF
--- a/tools/armips.cpp
+++ b/tools/armips.cpp
@@ -52,6 +52,7 @@ SOFTWARE.
 #include <vector>
 #include <cstdlib>
 #include <cstdarg>
+#include <cstdint>
 #include <cctype>
 #include <cstring>
 #include <cmath>


### PR DESCRIPTION
GCC 15 complains about this header missing, so fix that. Build still works on GCC 14 after this change